### PR TITLE
Fix confusion matrix

### DIFF
--- a/src/mnist/training.ts
+++ b/src/mnist/training.ts
@@ -161,5 +161,6 @@ export default class MnistTraining {
     const predictions = doPrediction(this.model, this.data);
     await showAccuracy(predictions, this.data, classNames);
     await showConfusion(predictions, this.data, classNames);
+    predictions.map(tensor => tensor.dispose());
   }
 }

--- a/src/mnist/vis.ts
+++ b/src/mnist/vis.ts
@@ -53,7 +53,6 @@ export async function showAccuracy(
   const classAccuracy = await tfvis.metrics.perClassAccuracy(labels, preds);
   const container = { name: "Accuracy", tab: "Evaluation" };
   tfvis.show.perClassAccuracy(container, classAccuracy, classNames);
-  labels.dispose();
 }
 
 export async function showConfusion(
@@ -67,8 +66,6 @@ export async function showConfusion(
     values: confusionMatrix,
     tickLabels: classNames
   });
-
-  labels.dispose();
 }
 
 export function openVis() {


### PR DESCRIPTION
- labels tensor passed to the showConfusionMatrix function\
	is disposed by the showAccuracy function
- removed the control of labels.dispose from both
- added the responsibility of disposing of the tensors to the callee

🤓